### PR TITLE
validate new schema before compare old and new

### DIFF
--- a/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/MetadataBackedDataStore.scala
+++ b/geomesa-index-api/src/main/scala/org/locationtech/geomesa/index/geotools/MetadataBackedDataStore.scala
@@ -240,6 +240,8 @@ abstract class MetadataBackedDataStore(config: NamespaceConfig) extends DataStor
         throw new IllegalArgumentException(s"Schema '$typeName' does not exist")
       }
 
+      GeoMesaSchemaValidator.validate(schema)
+
       validateSchemaUpdate(previousSft, schema)
 
       val sft = SimpleFeatureTypes.mutable(schema)


### PR DESCRIPTION
The dtg information is set during the verification. If  not verified, the default dtg information is changed and the update fails.